### PR TITLE
history-exec.bash: add missing keybindings

### DIFF
--- a/history-exec.bash
+++ b/history-exec.bash
@@ -49,5 +49,9 @@ bind -x '"\C-x\C-o": __fzf_rebind_ctrl_x_ctrl_p__'
 if [[ ! -o vi ]]; then
   bind '"\C-r": " \C-e\C-u\C-y\ey\C-u`__fzf_history__`\e\C-e\er\e^\C-x\C-o\C-x\C-p"'
 else
+  bind '"\C-x\C-a": vi-movement-mode'
+  bind '"\C-x\C-e": shell-expand-line'
+  bind '"\C-x\C-r": redraw-current-line'
+  bind '"\C-x^": history-expand-line'
   bind '"\C-r": "\C-x\C-addi`__fzf_history__`\C-x\C-e\C-x\C-r\C-x^\C-x\C-a$a\C-x\C-o\C-x\C-p"'
 fi


### PR DESCRIPTION
Looks like some previously existing vi-mode keybindings got lost.
Not sure why or when, but let's just add them back until somebody
complains :D

Fixes #5